### PR TITLE
drop params after init request

### DIFF
--- a/mds_provider_client/mds_provider_client.py
+++ b/mds_provider_client/mds_provider_client.py
@@ -4,6 +4,7 @@ MDS Provider API client implementation.
 from datetime import datetime
 import json
 import logging
+import time
 
 import requests
 from requests import Session
@@ -24,6 +25,7 @@ class ProviderClient(object):
         headers=None,
         timeout=10,
         max_attempts=5,
+        delay=1
     ):
         """
         Initialize a new ProviderClient object.
@@ -42,7 +44,10 @@ class ProviderClient(object):
         :max_attempts: The maximum number times to attempt to send a request, in the event
             of timeout (default 5). 
         
+        :delay: Number of seconds to wait between requests (default 1).
+
         """
+        self.delay = delay
         self.url = url
         self.token = token
         self.user = user
@@ -112,6 +117,8 @@ class ProviderClient(object):
             while attempts < self.max_attempts:
 
                 attempts += 1
+
+                time.sleep(self.delay)
 
                 try:
                     # get the data

--- a/mds_provider_client/mds_provider_client.py
+++ b/mds_provider_client/mds_provider_client.py
@@ -1,7 +1,6 @@
 """
 MDS Provider API client implementation. 
 """
-
 from datetime import datetime
 import json
 import logging
@@ -87,7 +86,6 @@ class ProviderClient(object):
 
         Returns list of records and stores them at `self.<endpoint>`. 
         """
-
         def __has_data(page):
             """
             Checks if this :page: has a "data" property with a non-empty payload
@@ -147,6 +145,10 @@ class ProviderClient(object):
 
             if not self.links:
                 break
+
+            # after the initial request, remove start/end time from request params
+            # because these are included in the pagination `links`
+            params = None
                 
             url = self.links.get("next")
 

--- a/mds_provider_client/mds_provider_client.py
+++ b/mds_provider_client/mds_provider_client.py
@@ -86,6 +86,7 @@ class ProviderClient(object):
 
         Returns list of records and stores them at `self.<endpoint>`. 
         """
+
         def __has_data(page):
             """
             Checks if this :page: has a "data" property with a non-empty payload
@@ -149,7 +150,7 @@ class ProviderClient(object):
             # after the initial request, remove start/end time from request params
             # because these are included in the pagination `links`
             params = None
-                
+
             url = self.links.get("next")
 
             if not paging or not url:

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
         "requests",
     ],
     packages=['mds_provider_client'],
-    version="0.1.3"
+    version="0.1.4"
 )


### PR DESCRIPTION
This commit updates the client to drop initial request parameters after the first /trips request is made. Prior to this commit requests for paginated data were malformed because they were combined with the initial request params as well as params already encoded in the pagination `links`.